### PR TITLE
Fix mistake when open square bracket

### DIFF
--- a/classes/Node/Container/Document.php
+++ b/classes/Node/Container/Document.php
@@ -753,6 +753,9 @@ class Node_Container_Document extends Node_Container
 				$tag_text .= $str[$i];
 		}
 
+		if ($tag_open)
+			$tag_text .= '[' . $tag;
+
 		$this->tag_text($tag_text);
 
 		if($this->throw_errors && !$this->current_tag instanceof Node_Container_Document)


### PR DESCRIPTION
When square bracket is opened and no tag is present before the end of text,
the text after this square bracket (and the square bracket) was not included
in the document node during the parsing
