### PR TITLE
Fix for links and parameters

### DIFF
--- a/classes/Node/Container/Document.php
+++ b/classes/Node/Container/Document.php
@@ -875,7 +875,7 @@ class Node_Container_Document extends Node_Container
 
 		// if this tag only has one = then there is only one attribute
 		// so add it all to default
-		if($attribs[0] == '=' && strrpos($attribs, '=') === 0)
+		if($attribs[0] == '=' && (strrpos($attribs, '=') === 0 || $attribs[0] == '='))
 			$ret['default'] = htmlentities(substr($attribs, 1), ENT_QUOTES | ENT_IGNORE, "UTF-8");
 		else
 		{


### PR DESCRIPTION
Fix for links and parameters that contains = symbol.
String for testing.
[URL=https://www.youtube.com/watch?v=v5Xr-WkW5JM]NASA’s Spitzer Reveals Largest Batch of Earth-Size, Habitable-Zone Planets Around a Single Star [/URL]